### PR TITLE
Increase timeout 3->6

### DIFF
--- a/lib/Tesla/API.pm
+++ b/lib/Tesla/API.pm
@@ -193,7 +193,7 @@ sub mech {
     my $www_mech = WWW::Mechanize->new(
         agent       => $self->_useragent_string,
         autocheck   => 0,
-        timeout     => 3,
+        timeout     => 6,
         cookie_jar  => {}
     );
 


### PR DESCRIPTION
 * 3: It almost never works for me:
   My Tesla account has my car registered with the name 'Tesla'.
   500 read timeout at /home/lace/perl5/lib/perl5/Tesla/API.pm line 140.
   Can't use string ("1") as a HASH ref while "strict refs" in use at .../Tesla/Vehicle.pm line 119.
 * 4: It still times out but rarely.
 * 5: I could not reproduce the timeout but it may not be completely
      safe being on the edge.