### PR TITLE
Fix compatibility with JSON <4 (specifically perl-JSON-2.59-2.el7)

### DIFF
--- a/lib/Tesla/API.pm
+++ b/lib/Tesla/API.pm
@@ -121,7 +121,7 @@ sub api {
         push @$header, 'Authorization' => $token_string;
     }
 
-    my $request = HTTP::Request->new($type, $url, $header, encode_json($api_params));
+    my $request = HTTP::Request->new($type, $url, $header, JSON->new->allow_nonref->encode($api_params));
 
     my $response = $self->mech->request($request);
 


### PR DESCRIPTION
hash- or arrayref expected (not a simple scalar, use allow_nonref to allow this) at .../Tesla/API.pm line 124.